### PR TITLE
Find first parent package.json file with "jest-multiple-result-processors" 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.3",
   "description": "A test result processor that allows adding multiple processors easily",
   "main": "src/index.js",
-  "repository": "https://github.com/meza/jest-multiple-result-processors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/meza/jest-multiple-result-processors"
+  },
   "author": "meza",
   "license": "MIT",
   "private": false,

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,11 @@ module.exports = function (results) {
   let config = {};
   let configDir = '';
 
-  for (let nextValue = f.next(); nextValue.done !== true; nextValue = f.next()) {
-    config = nextValue.value;
-    configDir = path.dirname(nextValue.filename);
+  for (let nextValue = f.next(); nextValue.done !== true && !configDir; nextValue = f.next()) {
+    if (nextValue.value.name !== 'jest-multiple-result-processors' && nextValue.value.hasOwnProperty('jestTestResultProcessors')) {
+      config = nextValue.value;
+      configDir = path.dirname(nextValue.filename);
+    }
   }
 
   if (!config.hasOwnProperty('jestTestResultProcessors')) {


### PR DESCRIPTION
Previously if you had an additional package.json file in a parent or ancestor directory of your project, jest-multiple-result-processors didn't stop at the project's package.json, but kept traversing the filesystem upwards and tried to get the "jestTestResultProcessors" config from a file further above.

After this commit, it will stop traversing the tree after finding the first package.json file that has "jestTestResultProcessors". This allows for a scoped config approach, in case you have nested projects.